### PR TITLE
docs: update guidelines about the `accepted` label

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To make the process as smooth as possible for everyone, please read the relevant
 
 1. **Issue first**
 
-   - Before starting work, confirm there is an open issue for the task and that it is not tagged `needs triage`.
+   - Before starting work, confirm there is an open issue for the task and that it is labeled `accepted`. Do **not** work on issues labeled `needs triage`.
    - **Exceptions:** Critical, unclassified production-blocking bugs. Trivial changes, such as typos or broken links.
 
 2. **Code style & formatting**


### PR DESCRIPTION
The `accepted` label provides clearer feedback about what is planned.